### PR TITLE
Fix code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -91,7 +91,7 @@ export function convertInReactSelectOptions (cars){
 export function transformarDadosParaChartJS(dados) {
     // Separar os dados em rótulos e conjuntos de dados
     const rotulos = dados.map(item => item?.MesReferencia)?.filter(item => item != undefined).reverse();
-    const valores = dados.map(item => parseFloat(item?.Valor?.replace('R$ ', '')?.replace('', '')))?.filter(item => isNaN(item) == false).map(item => item*1000).reverse();
+    const valores = dados.map(item => parseFloat(item?.Valor?.replace('R$ ', '')))?.filter(item => isNaN(item) == false).map(item => item*1000).reverse();
 
     // Criar objeto de conjunto de dados no formato do Chart.js
     const dataset = {


### PR DESCRIPTION
Fixes [https://github.com/oseiasal/fipe_historico/security/code-scanning/1](https://github.com/oseiasal/fipe_historico/security/code-scanning/1)

To fix the problem, we need to remove the redundant replacement of an empty string with itself. This can be done by simply eliminating the `.replace('', '')` part of the chain. This change will not affect the existing functionality but will clean up the code and remove the unnecessary operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
